### PR TITLE
Fix: Increase version numbers to 0.2.0

### DIFF
--- a/docs/components/miranum-connect/intro-miranum-connect.md
+++ b/docs/components/miranum-connect/intro-miranum-connect.md
@@ -6,7 +6,7 @@ description: "This section contains an introduction to Miranum-Connect."
 ---
 
 :::note
-Miranum-Connect is currently in early stage of development. No version is officially released yet. When using the framework
+Miranum-Connect is currently in early stage of development. Alpha version 0.2.0 is the most up to date one. When using the framework
 by cloning the repository it can happen that the API changes in future versions
 :::
 

--- a/docs/components/miranum-connect/java-client/miranum-message.md
+++ b/docs/components/miranum-connect/java-client/miranum-message.md
@@ -14,7 +14,7 @@ To use the Miranum-Message, declare the following Maven dependency in your proje
 <dependency>
     <groupId>io.miragon.miranum</groupId>
     <artifactId>message-api</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 

--- a/docs/components/miranum-connect/java-client/miranum-process.md
+++ b/docs/components/miranum-connect/java-client/miranum-process.md
@@ -14,7 +14,7 @@ To use the Miranum-Process, declare the following Maven dependency in your proje
 <dependency>
     <groupId>io.miragon.miranum</groupId>
     <artifactId>process-api</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 

--- a/docs/components/miranum-connect/java-client/miranum-worker.md
+++ b/docs/components/miranum-connect/java-client/miranum-worker.md
@@ -15,7 +15,7 @@ To use the Miranum-Worker, declare the following Maven dependency in your projec
 <dependency>
     <groupId>io.miragon.miranum</groupId>
     <artifactId>worker-api</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0</version>
 </dependency>
 ```
 
@@ -131,19 +131,16 @@ needs to be added to the project. Additionally, it is required to add a specific
 <dependency>
    <groupId>io.miragon.miranum</groupId>
    <artifactId>element-template-api</artifactId>
-   <version>0.1.0-SNAPSHOT</version>
+   <version>0.2.0</version>
 </dependency>
 ```
-Having done so, the `@GenerateElementTemplates` annotation needs to be added to a Miranum Worker method.
+Having done so, the `@ElementTemplate` annotation needs to be added to a Miranum Worker method.
 The properties shown below are required when adding the annotation:
 ```java
 @Worker(type = "doSomething")
-@GenerateElementTemplate(
+@ElementTemplate(
         name = "Do Something",
-        id = "do-something",
-        type = "doSomething",
-        appliesTo = {BPMNElementType.BPMN_SERVICE_TASK},
-        version = 0.1)
+        description = "This is a description")
 public void doSomething(DoSomethingCommand doSomethingCommand) {};
 ```
 

--- a/docs/components/miranum-connect/java-client/quick-reference.md
+++ b/docs/components/miranum-connect/java-client/quick-reference.md
@@ -12,7 +12,7 @@ To use the Java Miranum-Connect library, declare the following Maven dependency 
 <dependency>
  <groupId>io.miragon.miranum</groupId>
  <artifactId>connect</artifactId>
- <version>0.1.0-SNAPSHOT</version>
+ <version>0.2.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description 
Increase version numbers of miranum in docs to 0.2.0 as described here: https://github.com/Miragon/miranum-connect/pull/149

## Checklist 
- [x] No obvious errors or bugs (`npm run start` works)
- [x] Followed the [Style Guides](https://github.com/camunda/camunda-platform-docs/blob/main/howtos/technical-writing-styleguide.md)
- [x] Using a semantic commit messages as described in [here](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
